### PR TITLE
Update with new intermediate cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 
 
 conf/dst-x3-root.pem
+conf/letsencrypt-authority-x1.pem

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -41,7 +41,7 @@ class HomeController @Inject()(downloader: CertificateDownloader,
 
   def index = Action.async { implicit request =>
     // Download the LC certificates if necessary
-    val downloadFuture = if (downloader.certificatesExist()) {
+    val downloadFuture = if (downloader.allCertificatesExist()) {
       Future.successful(())
     } else {
       downloader.downloadCertificates()

--- a/app/controllers/LetsEncryptWSClient.scala
+++ b/app/controllers/LetsEncryptWSClient.scala
@@ -30,6 +30,7 @@ class LetsEncryptWSClient(lifecycle: ApplicationLifecycle,
       |      stores = [
       |        # Seems to be required for https://helloworld.letsencrypt.com
       |        { type = "PEM", path = "./conf/dst-x3-root.pem" }
+      |        { type = "PEM", path = "./conf/letsencrypt-authority-x1.pem" }
       |      ]
       |    }
       |  }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,8 +8,17 @@ play.i18n {
 
 include "ws"
 
-letsencrypt.root.url="https://bugzilla.mozilla.org/attachment.cgi?id=276893"
-letsencrypt.root.path="./conf/dst-x3-root.pem"
+# Use the ascii encoded DER certificate from certificate authority.
+# see https://community.letsencrypt.org/t/helloworld-letsencrypt-org-can-only-find-certificate-with-dst-x3-loaded/
+letsencrypt.root.certificates = [
+  { path: "./conf/dst-x3-root.pem", url: "https://crt.sh/?d=8395" },
+  { path: "./conf/letsencrypt-authority-x1.pem", url:"https://crt.sh/?d=9314792" }
+]
+
+# You can see what certificate chain is being used with:
+#
+# keytool -printcert -sslserver helloworld.letsencrypt.org -rfc
+
 
 # It can be helpful to run WS future results in a different dispatcher
 # so it doesn't compete with the action EC that does page renders...

--- a/conf/ws.conf
+++ b/conf/ws.conf
@@ -5,9 +5,10 @@ play.ws {
   # ~~~~~
   ssl {
     debug {
-      # Also export JAVA_OPTS="$JAVA_OPTS -Djava.security.debug=x509"
+      # Also export JAVA_OPTS="$JAVA_OPTS -Djava.security.debug='certpath x509'"
       trustmanager = true
       certpath = true
+      all = true
     }
 
     trustManager = {


### PR DESCRIPTION
There's now a new letsencrypt intermediate certificate X1 which is also not in Java's trust store and so must be downloaded.
